### PR TITLE
[Feature] Filter Extension

### DIFF
--- a/js/config.js
+++ b/js/config.js
@@ -12,7 +12,8 @@ ExtensityConfiguration = function() {
 ExtensityConfiguration.prototype.defaults = {
 	showHeader: true,
 	groupApps: true,
-	appsFirst: false
+	appsFirst: false,
+	filterBox: true
 };
 
 // Set preferences from localStorage, defaults, or null (in that order)

--- a/js/engine.js
+++ b/js/engine.js
@@ -23,8 +23,9 @@ Extensity.prototype.templates = {
 	section: '<div class="extension-section"><span>%s</span></div>',
 	// Parameters are: statusClass, item id, icon, item name
 	extensionItem: '<a class="extension-item extension-trigger %s" id="%s" href="#"><img src="%s" width="16px" height="16px" /> <span>%s</span></a>',
-	appItem: '<a class="extension-item %s extension-trigger" id="%s" href="#"><img src="%s" width="16px" height="16px" /> <span>%s</span></a>'
-}
+	appItem: '<a class="extension-item %s extension-trigger" id="%s" href="#"><img src="%s" width="16px" height="16px" /> <span>%s</span></a>',
+	filterBox: '<input class="filter-input filter-trigger" type="text" id="filter" placeholder="Search Extensions">'
+};
 
 // CSS classes
 Extensity.prototype.classes = {
@@ -78,8 +79,15 @@ Extensity.prototype.refreshList = function() {
 	var currentSection = null;
 	var hasMultipleExtensionTypes = self.hasMultipleExtensionTypes();
 	var list = $('#list');
+
 	// Clean content first
 	list.html('');
+
+	// Checking config and append FilterBox
+	if(self.cache.options.filterBox)
+	{
+		list.append(self.addFilterBox());
+	}
 
 	// Append extensions
 	$(self.cache.extensions).each(function(i,item) {
@@ -114,6 +122,31 @@ Extensity.prototype.shouldExcludeFromList = function(item) {
 	return (item.name == self.name) || (item.type && self.exclude_types.indexOf(item.type)>=0);
 };
 
+Extensity.prototype.filterExtensions = function(filterText) {
+	filterText = filterText || '';
+	filterText = filterText.toLowerCase();
+
+	$('.extension-trigger').each(function() {
+		var $item = $(this);
+		var itemName = $item.find('span').text().toLowerCase();
+
+		if(filterText === '' || _.str.include(itemName, filterText))
+		{
+			$item.removeClass('hide');
+		}
+		else
+		{
+			$item.addClass('hide')
+		}
+	});
+};
+
+// Add filter input box
+Extensity.prototype.addFilterBox = function() {
+	var self = this;
+	return _(self.templates.filterBox).sprintf();
+};
+
 // Add an item to the list
 Extensity.prototype.addListItem = function(item) {
 	var self = this;
@@ -122,7 +155,7 @@ Extensity.prototype.addListItem = function(item) {
 		item.id,
 		self.getSmallestIconUrl(item.icons),
 		_(item.name).prune(35)
-	)
+	);
 };
 
 //Add an section header to the list
@@ -168,6 +201,14 @@ Extensity.prototype.captureEvents = function() {
 		$(this).parent().trigger('click');
 	});
 
+	if(self.cache.options.filterBox)
+	{
+		$('.filter-trigger').off();
+		$('.filter-trigger').on('keyup', function(ev) {
+			var inputVal = $(this).val();
+			self.filterExtensions(inputVal);
+		});
+	}
 };
 
 // Open a new tab

--- a/options.html
+++ b/options.html
@@ -31,6 +31,12 @@
 			</label>
 		</div>
 		<div class="field">
+			<input type="checkbox" name="filterBox" id="filterBox" />
+			<label for="filterBox">
+				Show Filter Box
+			</label>
+		</div>
+		<div class="field">
 			<button id="save">Save</button>
 			<a href="#" id="close">Close</a>
 			<span id="save-result"></span>

--- a/styles/main.css
+++ b/styles/main.css
@@ -143,3 +143,17 @@ body {
 .extension-item.disabled img {
 	opacity: 0.3;
 }
+
+.filter-input {
+	width: 100%;
+	background: #fff;
+	margin-bottom: 4%;
+	border: 1px solid #ccc;
+	padding: 2%;
+	font-family: 'Open Sans',sans-serif;
+	color: #555;
+}
+
+.hide {
+	display: none;
+}


### PR DESCRIPTION
Hi, I added a filtering function to Extensity.

Extensity is very convenient until I installed tons of extensions that I have to search for a specific one to toggle.

I added an attribute in option page (which I let it to be toggled on by default).
![screen shot 2015-04-03 at 11 52 07 pm](https://cloud.githubusercontent.com/assets/2673743/6984709/4569bf68-da5e-11e4-9462-8d792af0cbff.png)

And when checked. A input box will be shown after header.
![screen shot 2015-04-03 at 11 52 33 pm](https://cloud.githubusercontent.com/assets/2673743/6984718/6ee641f4-da5e-11e4-9671-be499c732443.png)

Input string is compared with  extensions' names by using `underscore.string.include`. The unmatched extensions will be hidden.
![screen shot 2015-04-03 at 11 53 06 pm](https://cloud.githubusercontent.com/assets/2673743/6984730/97914b3a-da5e-11e4-9fff-9af4187032b9.png)
