### PR TITLE
issue #25 fixed - extension install type differentiator

### DIFF
--- a/index.html
+++ b/index.html
@@ -58,7 +58,7 @@
 		</ul>
 		<h1 data-sbind="visible: listedExtensions.any">Extensions</h1>
 		<ul data-sbind="foreach: listedExtensions">
-			<li class="extension" data-sbind="click: toggle, css:{disabled: disabled}"><img width="16px" height="16px" data-sbind="attr:{src:icon}" /> <span data-sbind="text: short_name"></span></li>
+			<li class="extension" data-sbind="click: toggle, css:{disabled: disabled}"><img width="16px" height="16px" data-sbind="attr:{src:icon}" /> <span data-sbind="text: short_name"></span><i data-sbind="visible: installType == 'development', attr:{title: 'Unpacked Extension'}" class="fa fa-flask"></i></li>
 		</ul>
 	</section>
 
@@ -66,7 +66,7 @@
 	<section data-sbind="if: !opts.appsFirst() && opts.groupApps()">
 		<h1 data-sbind="visible: listedExtensions.any">Extensions</h1>
 		<ul data-sbind="foreach: listedExtensions">
-			<li class="extension" data-sbind="click: toggle, css:{disabled: disabled}"><img width="16px" height="16px" data-sbind="attr:{src:icon}" /> <span data-sbind="text: short_name"></span></li>
+			<li class="extension" data-sbind="click: toggle, css:{disabled: disabled}"><img width="16px" height="16px" data-sbind="attr:{src:icon}" /> <span data-sbind="text: short_name"></span><i data-sbind="visible: installType == 'development', attr:{title: 'Unpacked Extension'}" class="fa fa-flask"></i></li>
 		</ul>
 		<h1 data-sbind="visible: listedApps.any">Apps</h1>
 		<ul data-sbind="foreach: listedApps">

--- a/js/engine.js
+++ b/js/engine.js
@@ -175,6 +175,7 @@ var ExtensionModel = function(e) {
   self.isApp = ko.observable(item.isApp);
   self.icon = smallestIcon(item.icons);
   self.status = ko.observable(item.enabled);
+  self.installType = item.installType;
 
   self.disabled = ko.pureComputed(function() {
     return !self.status();


### PR DESCRIPTION
issue #25 fixed - extension install type differentiator

If installType is 'developer' - flask icon (intent - experiment) is shown next extension name.
This change does not affect - normal users.