### PR TITLE
Migrate to MV3 (partially)

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Extensity",
   "version": "1.11.0",
-  "manifest_version": 2,
+  "manifest_version": 3,
   "description": "Quickly enable/disable Google Chrome extensions",
   "options_page": "options.html",
   "icons" : {
@@ -9,14 +9,13 @@
     "48" : "images/icon48.png",
     "128" : "images/icon128.png"
   },
-  "browser_action": {
+  "action": {
     "default_icon": "images/iconbar.png",
     "default_title": "Extensity",
     "default_popup": "index.html"
   },
   "background": {
-    "scripts": ["js/migration.js"],
-    "persistent": false
+    "service_worker": "js/migration.js"
   },
   "permissions": ["management","storage"]
 }


### PR DESCRIPTION
Resolves #71

### Changes

Updated the Manifest version to Manifest V3, the latest extensions platform, and changed a few other things to complete the update.

### Why these changes?

Extensity is currently running on the Manifest V2 platform, which currently looks like it will be deprecated sometime in 2023. More information on #71.

### Tests

Tested in Edge. The popup and options menu seem to work fine, though `migration.js` doesn't work at the moment. I don't have much JS or MV3 migration knowledge, so someone might have to come in and help with that.

I don't have Git or npm, but I hope it works okay. You will probably need to do additional steps to make it work on Firefox.